### PR TITLE
feat: add zenity fallback

### DIFF
--- a/Merge Media Files
+++ b/Merge Media Files
@@ -13,6 +13,14 @@ echo "---- $(date) start ----"
 # -------------------- kleine Utils --------------------
 bin_exists() { command -v "$1" >/dev/null 2>&1; }
 
+# Verfügbares GUI-Tool ermitteln (yad bevorzugt, sonst zenity)
+GUI_TOOL=""
+if bin_exists yad; then
+  GUI_TOOL=yad
+elif bin_exists zenity; then
+  GUI_TOOL=zenity
+fi
+
 # Prozent-Decoding (aus file:// URIs) – bevorzugt python3, Fallback: nur %20 -> Leerzeichen
 uridecode() {
   if bin_exists python3; then
@@ -33,7 +41,7 @@ PY
 }
 
 # -------------------- Abhängigkeiten prüfen --------------------
-need_cmds=("ffmpeg" "yad")
+need_cmds=("ffmpeg")
 missing=()
 for c in "${need_cmds[@]}"; do
   bin_exists "$c" || missing+=("$c")
@@ -44,14 +52,18 @@ if ((${#missing[@]})); then
   if printf '%s\n' "${missing[@]}" | grep -q '^ffmpeg$'; then
     rpmfusion_hint=$'\nHinweis (Fedora): ffmpeg ist i. d. R. in RPM Fusion.\n  sudo dnf install -y https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm\n  sudo dnf install -y ffmpeg'
   fi
-  msg=$'Fehlende Abhängigkeiten: '"${missing[*]}"$'\n\nUbuntu/Debian:  sudo apt install ffmpeg yad\nFedora:         sudo dnf install yad\n                (ffmpeg über RPM Fusion)\n'"${rpmfusion_hint}"
-  if bin_exists yad; then
-    yad --title="Abhängigkeiten fehlen" --text="$msg" --button="OK":0 --center || true
-  elif bin_exists zenity; then
-    zenity --info --title="Abhängigkeiten fehlen" --text="$msg" || true
-  else
-    echo "$msg" >&2
-  fi
+  msg=$'Fehlende Abhängigkeiten: '"${missing[*]}"$'\n\nUbuntu/Debian:  sudo apt install ffmpeg\nFedora:         sudo dnf install ffmpeg\n                (ffmpeg über RPM Fusion)\n'"${rpmfusion_hint}"
+  case "$GUI_TOOL" in
+    yad)
+      yad --title="Abhängigkeiten fehlen" --text="$msg" --button="OK":0 --center || true
+      ;;
+    zenity)
+      zenity --info --title="Abhängigkeiten fehlen" --text="$msg" || true
+      ;;
+    *)
+      echo "$msg" >&2
+      ;;
+  esac
   exit 1
 fi
 
@@ -73,11 +85,17 @@ elif (($#>0)); then
   mapfile -t paths < <(printf '%s\n' "$@")
   SELECTED_LINES="$(printf '%s\n' "${paths[@]}" | sed '/^$/d')"
 else
-  if bin_exists yad; then
-    yad --image=dialog-error --text="Keine Dateien ausgewählt/übergeben." --button="OK":0 --center || true
-  else
-    echo "Keine Dateien ausgewählt/übergeben." >&2
-  fi
+  case "$GUI_TOOL" in
+    yad)
+      yad --image=dialog-error --text="Keine Dateien ausgewählt/übergeben." --button="OK":0 --center || true
+      ;;
+    zenity)
+      zenity --error --text="Keine Dateien ausgewählt/übergeben." || true
+      ;;
+    *)
+      echo "Keine Dateien ausgewählt/übergeben." >&2
+      ;;
+  esac
   exit 1
 fi
 
@@ -131,16 +149,26 @@ while IFS= read -r f; do
   printf '%s\n' "$(basename "$f")" >> "$TMP_NAMES"
 done <<< "$SORTED_FILES"
 
-# Liste per STDIN an yad geben: eine Zeile = eine Tabellenzeile
-if command -v yad >/dev/null 2>&1; then
-  yad --title="Zusammenfügen bestätigen" \
-      --text="Die folgenden Dateien werden in dieser Reihenfolge zusammengefügt:" \
-      --list --no-headers --no-click --scroll \
-      --column="Dateien" \
-      --width=500 --height="$HEIGHT" --center \
-      --button="Abbrechen":1 --button="OK":0 \
-      < "$TMP_NAMES" || { rm -f "$TMP_NAMES"; exit 1; }
-fi
+# Liste per STDIN an GUI geben: eine Zeile = eine Tabellenzeile
+case "$GUI_TOOL" in
+  yad)
+    yad --title="Zusammenfügen bestätigen" \
+        --text="Die folgenden Dateien werden in dieser Reihenfolge zusammengefügt:" \
+        --list --no-headers --no-click --scroll \
+        --column="Dateien" \
+        --width=500 --height="$HEIGHT" --center \
+        --button="Abbrechen":1 --button="OK":0 \
+        < "$TMP_NAMES" || { rm -f "$TMP_NAMES"; exit 1; }
+    ;;
+  zenity)
+    zenity --list --title="Zusammenfügen bestätigen" \
+           --text="Die folgenden Dateien werden in dieser Reihenfolge zusammengefügt:" \
+           --column="Dateien" --hide-header \
+           --width=500 --height="$HEIGHT" \
+           --cancel-label="Abbrechen" --ok-label="OK" \
+           < "$TMP_NAMES" || { rm -f "$TMP_NAMES"; exit 1; }
+    ;;
+esac
 
 rm -f "$TMP_NAMES"
 
@@ -155,11 +183,17 @@ AVAILABLE_SPACE=$(df -Pk -- "${DIRNAME}" | awk 'END{print $4}')
 echo "REQUIRED_SPACE=${REQUIRED_SPACE} KB, AVAILABLE_SPACE=${AVAILABLE_SPACE} KB"
 
 if (( AVAILABLE_SPACE < REQUIRED_SPACE )); then
-  if bin_exists yad; then
-    yad --image=dialog-error --button=gtk-ok:0 --center --text="Nicht genügend Speicherplatz verfügbar!" || true
-  else
-    echo "Nicht genügend Speicherplatz." >&2
-  fi
+  case "$GUI_TOOL" in
+    yad)
+      yad --image=dialog-error --button=gtk-ok:0 --center --text="Nicht genügend Speicherplatz verfügbar!" || true
+      ;;
+    zenity)
+      zenity --error --text="Nicht genügend Speicherplatz verfügbar!" || true
+      ;;
+    *)
+      echo "Nicht genügend Speicherplatz." >&2
+      ;;
+  esac
   exit 1
 fi
 
@@ -186,19 +220,31 @@ echo "NEED_REENCODE=$NEED_REENCODE"
 
 # Nachfrage bei Re-Encode
 if (( NEED_REENCODE == 1 )); then
-  if bin_exists yad; then
-    yad --title="Neukodierung erforderlich" --text="Die Dateien müssen neukodiert werden. Fortfahren?" --button="Nein":1 --button="Ja":0 || { rm -f "${LIST_FILE}"; exit 1; }
-  fi
+  case "$GUI_TOOL" in
+    yad)
+      yad --title="Neukodierung erforderlich" --text="Die Dateien müssen neukodiert werden. Fortfahren?" --button="Nein":1 --button="Ja":0 || { rm -f "${LIST_FILE}"; exit 1; }
+      ;;
+    zenity)
+      zenity --question --title="Neukodierung erforderlich" --text="Die Dateien müssen neukodiert werden. Fortfahren?" --cancel-label="Nein" --ok-label="Ja" || { rm -f "${LIST_FILE}"; exit 1; }
+      ;;
+  esac
 fi
 
 # -------------------- Fortschritts-UI via FIFO (immer sichtbar) --------------------
 PROG_FIFO="$(mktemp -u)"
 mkfifo "$PROG_FIFO"
-if bin_exists yad; then
-  yad --progress --pulsate --no-cancel --auto-close --title="Zusammenfügen läuft" --text="# Bitte warten..." < "$PROG_FIFO" &
-  YAD_PID=$!
-  echo "YAD_PID=$YAD_PID"
-fi
+case "$GUI_TOOL" in
+  yad)
+    yad --progress --pulsate --no-cancel --auto-close --title="Zusammenfügen läuft" --text="# Bitte warten..." < "$PROG_FIFO" &
+    GUI_PID=$!
+    echo "GUI_PID=$GUI_PID"
+    ;;
+  zenity)
+    zenity --progress --pulsate --no-cancel --auto-close --title="Zusammenfügen läuft" --text="# Bitte warten..." < "$PROG_FIFO" &
+    GUI_PID=$!
+    echo "GUI_PID=$GUI_PID"
+    ;;
+esac
 
 set +e
 FF_ERR=0
@@ -231,18 +277,30 @@ rm -f "$PROG_FIFO" "${LIST_FILE}"
 
 if (( FF_ERR != 0 )); then
   echo "ffmpeg exit code: $FF_ERR"
-  if bin_exists yad; then
-    yad --image=dialog-error --text="Fehler beim Zusammenfügen (Code $FF_ERR).\nSiehe Log: $LOGFILE" --button="OK":0 --center || true
-  else
-    echo "Fehler beim Zusammenfügen (Code $FF_ERR). Siehe Log: $LOGFILE" >&2
-  fi
+  case "$GUI_TOOL" in
+    yad)
+      yad --image=dialog-error --text="Fehler beim Zusammenfügen (Code $FF_ERR).\nSiehe Log: $LOGFILE" --button="OK":0 --center || true
+      ;;
+    zenity)
+      zenity --error --text="Fehler beim Zusammenfügen (Code $FF_ERR).\nSiehe Log: $LOGFILE" || true
+      ;;
+    *)
+      echo "Fehler beim Zusammenfügen (Code $FF_ERR). Siehe Log: $LOGFILE" >&2
+      ;;
+  esac
   exit "$FF_ERR"
 else
-  if bin_exists yad; then
-    yad --image=dialog-information --text="Erfolg: ${OUTPUT_FILE}" --button="OK":0 --center || true
-  else
-    echo "Erfolg: ${OUTPUT_FILE}"
-  fi
+  case "$GUI_TOOL" in
+    yad)
+      yad --image=dialog-information --text="Erfolg: ${OUTPUT_FILE}" --button="OK":0 --center || true
+      ;;
+    zenity)
+      zenity --info --text="Erfolg: ${OUTPUT_FILE}" || true
+      ;;
+    *)
+      echo "Erfolg: ${OUTPUT_FILE}"
+      ;;
+  esac
 fi
 
 echo "---- $(date) end ----"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [🇩🇪 Deutsche Version](README_de.md)
 
-![License: CC0](https://img.shields.io/badge/License-CC0-lightgrey.svg) ![Shell](https://img.shields.io/badge/Made%20with-Bash-4EAA25.svg?logo=gnu-bash&logoColor=white) ![ffmpeg](https://img.shields.io/badge/Uses-ffmpeg-blue.svg) ![yad](https://img.shields.io/badge/GUI-yad-purple.svg)
+![License: CC0](https://img.shields.io/badge/License-CC0-lightgrey.svg) ![Shell](https://img.shields.io/badge/Made%20with-Bash-4EAA25.svg?logo=gnu-bash&logoColor=white) ![ffmpeg](https://img.shields.io/badge/Uses-ffmpeg-blue.svg) ![yad](https://img.shields.io/badge/GUI-yad-purple.svg) ![zenity](https://img.shields.io/badge/GUI-zenity-purple.svg)
 
 **CatMerge** is a shell script that lets you merge video/audio files right from your file manager.  
 Ideal for **action cams or drones** that split recordings into 4-GB segments.
@@ -17,17 +17,17 @@ If that isn’t possible (e.g. variable bitrate), it asks to **re-encode**.
 ## Requirements
 
 - `ffmpeg`
-- `yad` (for dialogs; script still prints to terminal if missing)
+- `yad` or `zenity` (for dialogs; script still prints to terminal if neither is available)
 
 Ubuntu/Debian:
 ```bash
 sudo apt update
-sudo apt install -y ffmpeg yad
+sudo apt install -y ffmpeg yad  # or: zenity
 ```
 
 Fedora:
 ```bash
-sudo dnf install -y yad
+sudo dnf install -y yad  # or: zenity
 # ffmpeg via RPM Fusion
 sudo dnf install -y   https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
 sudo dnf install -y ffmpeg

--- a/README_de.md
+++ b/README_de.md
@@ -4,8 +4,9 @@
 
 ![Lizenz: CC0](https://img.shields.io/badge/Lizenz-CC0-lightgrey.svg)  
 ![Shell](https://img.shields.io/badge/Geschrieben%20in-Bash-4EAA25.svg?logo=gnu-bash&logoColor=white)  
-![ffmpeg](https://img.shields.io/badge/Nutzt-ffmpeg-blue.svg)  
+![ffmpeg](https://img.shields.io/badge/Nutzt-ffmpeg-blue.svg)
 ![yad](https://img.shields.io/badge/GUI-yad-purple.svg)
+![zenity](https://img.shields.io/badge/GUI-zenity-purple.svg)
 
 **CatMerge** ist ein Shell-Skript, mit dem du Video- oder Audiodateien direkt im Dateimanager zusammenfügen kannst.  
 Perfekt für **Action-Cams oder Drohnen**, die Aufnahmen in 4-GB-Segmente aufteilen.
@@ -18,17 +19,17 @@ Falls dies nicht möglich ist (z. B. bei variabler Bitrate), wirst du gefragt, o
 ## Voraussetzungen
 
 - `ffmpeg`
-- `yad` (für Dialoge; wenn nicht vorhanden, wird ins Terminal ausgegeben)
+- `yad` oder `zenity` (für Dialoge; wenn keines vorhanden ist, wird ins Terminal ausgegeben)
 
 Ubuntu/Debian:
 ```bash
 sudo apt update
-sudo apt install -y ffmpeg yad
+sudo apt install -y ffmpeg yad  # oder: zenity
 ```
 
 Fedora:
 ```bash
-sudo dnf install -y yad
+sudo dnf install -y yad  # oder: zenity
 # ffmpeg über RPM Fusion
 sudo dnf install -y   https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
 sudo dnf install -y ffmpeg


### PR DESCRIPTION
## Summary
- detect available GUI tool and fall back to zenity when yad is missing
- allow running without yad by making it optional and using zenity or terminal output
- document zenity as an optional dialog provider alongside yad

## Testing
- `bash -n 'Merge Media Files'`
- `shellcheck 'Merge Media Files'` (1 info)


------
https://chatgpt.com/codex/tasks/task_e_68b5bc05bb60832c9ba7701ece3864c7