### PR TITLE
Re-enable strict error handling after ffmpeg

### DIFF
--- a/Merge Media Files
+++ b/Merge Media Files
@@ -268,6 +268,8 @@ else
   ffmpeg -y -f concat -safe 0 -i "${LIST_FILE}" -c copy "${OUTPUT_FILE}" || FF_ERR=$?
 fi
 
+set -e
+
 # Fortschritt schließen / Meldung
 {
   echo 100


### PR DESCRIPTION
## Summary
- Restore strict error checking after the ffmpeg block so later commands run with `set -e`

## Testing
- `bash -n 'Merge Media Files'`
- `shellcheck 'Merge Media Files'` *(SC2086 info)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d42707d8832c9f991f732b38146c